### PR TITLE
Add virtiofs mounts support

### DIFF
--- a/initcpio/hooks/bootstrap
+++ b/initcpio/hooks/bootstrap
@@ -46,7 +46,7 @@ env | while IFS= read -r entry; do
             target=${entry#*=}
             dst="/new_root/$target"
             mkdir -p "$dst" || true
-            mount -t virtiofs "$fs" "$target"
+            mount -t virtiofs "$fs" "$dst"
             ;;
       esac
    done

--- a/initcpio/hooks/bootstrap
+++ b/initcpio/hooks/bootstrap
@@ -29,23 +29,24 @@ process_mounts() {
       # has a valid target
       if [ ! -z "$target" ]; then
          dst="/new_root/$target"
-         mkdir -p ${dst} || true
+         mkdir -p "${dst}" || true
          echo "mounting $name on $target"
          mount "/dev/$name" "$dst"
       fi
    done
 }
   
+# manually tested on export qsfs_qsfsnamewithoutdashesorcolons="/New Folder/targ=t"
 process_virtiofs_mounts() {
-   for entry in $(cat ./cmdline) ; do
+env | while IFS= read -r entry; do
       case $entry in
-      qsfs:*)
-            prefixless=${entry#qsfs:}
-            fs=${prefixless%=*}
-            target=${prefixless#*=}
+      qsfs_*)
+            fs=${entry%%=*}
+            fs=${fs#qsfs_}
+            target=${entry#*=}
             dst="/new_root/$target"
-            mkdir -p $dst
-            mount -t virtiofs $fs $dst
+            mkdir -p "$dst" || true
+            mount -t virtiofs "$fs" "$target"
             ;;
       esac
    done

--- a/initcpio/hooks/bootstrap
+++ b/initcpio/hooks/bootstrap
@@ -35,6 +35,21 @@ process_mounts() {
       fi
    done
 }
+  
+process_virtiofs_mounts() {
+   for entry in $(cat ./cmdline) ; do
+      case $entry in
+      qsfs:*)
+            prefixless=${entry#qsfs:}
+            fs=${prefixless%=*}
+            target=${prefixless#*=}
+            dst="/new_root/$target"
+            mkdir -p $dst
+            mount -t virtiofs $fs $dst
+            ;;
+      esac
+   done
+}
 
 run_latehook() {
    echo "settign up environment"
@@ -47,6 +62,9 @@ run_latehook() {
 
    echo "process mounts"
    process_mounts
+
+   echo "process virtiofs mounts"
+   process_virtiofs_mounts
 
    echo "checking for /etc/environment"
    file=/new_root/etc/environment

--- a/initcpio/hooks/bootstrap
+++ b/initcpio/hooks/bootstrap
@@ -44,8 +44,14 @@ env | while IFS= read -r entry; do
             fs=${entry%%=*}
             fs=${fs#qsfs_}
             target=${entry#*=}
+            if [ "$target" = "/" ]; then
+               echo "invalid mount target /"
+               continue
+            fi
+
             dst="/new_root/$target"
             mkdir -p "$dst" || true
+            echo "mounting virtiofs $fs on $target"
             mount -t virtiofs "$fs" "$dst"
             ;;
       esac


### PR DESCRIPTION
`/proc/cmdline` is scanned for entries in the format `qsfs:<fs>=<target>`, creates `target` if it doesn't exist and mounts the filesystem on target. 