### PR TITLE
If a nic is configured in cmdline bring it up

### DIFF
--- a/init
+++ b/init
@@ -75,7 +75,8 @@ run_hookfunctions 'run_cleanuphook' 'cleanup hook' $CLEANUPHOOKS
 # 'set --' in .zosrc requires it to run outside of any function
 [ -f /new_root/.zosrc ] && source /new_root/.zosrc
 
-rm -f /new_root/.zosrc
+# for debugging purposes, we keep .zosrc
+# rm -f /new_root/.zosrc
 
 if [ "$(stat -c %D /)" = "$(stat -c %D /new_root)" ]; then
     # Nothing got mounted on /new_root. This is the end, we don't know what to do anymore

--- a/setupnetwork
+++ b/setupnetwork
@@ -24,14 +24,17 @@ sysctl -w net.ipv6.conf.all.accept_ra_defrtr=2
 
 setup_nic() {
 	nic=$1
-	input=$2
-	ips=(${input//;/ })
-
 	if ! ip l show "${nic}"; then
 		return
 	fi
-
 	ip l set "$nic" up
+
+	input=$2
+	if [ -z "$input" ]; then
+		return
+	fi
+
+	ips=(${input//;/ })
 	for ip in ${ips[@]}; do
 		ip a a "$ip" dev "$nic"
 	done
@@ -61,9 +64,7 @@ setup_nics() {
 		nic="eth${index}"
 		arg="net_${nic}"
 		value=$(eval echo \$$arg)
-		if [ -z "$value" ]; then
-			continue
-		fi
+
 		# so we now have nic wit given config data
 		setup_nic $nic $value
 	done


### PR DESCRIPTION
This is needed in case of SLAAC Ipv6, where we just
need to bring the nic up, but not set any ips